### PR TITLE
Create Hermes device that can use the xdma driver

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -2065,6 +2065,13 @@ F: hw/rx/
 F: include/hw/intc/rx_icu.h
 F: include/hw/rx/
 
+Hermes
+M: Martin Oliveira <martin.oliveira@eideticom.com>
+R: Stephen Bates <stephen.bates@eideticom.com>
+W: https://github.com/Eideticom/eid-hermes/
+S: Supported
+F: hw/misc/hermes.c
+
 Subsystems
 ----------
 Audio

--- a/configure
+++ b/configure
@@ -519,6 +519,7 @@ fuzzing="no"
 rng_none="no"
 secret_keyring=""
 libdaxctl=""
+libubpf=""
 
 supported_cpu="no"
 supported_os="no"
@@ -1639,6 +1640,10 @@ for opt do
   --enable-libdaxctl) libdaxctl=yes
   ;;
   --disable-libdaxctl) libdaxctl=no
+  ;;
+  --disable-libubpf) libubpf="no"
+  ;;
+  --enable-libubpf) libubpf="yes"
   ;;
   *)
       echo "ERROR: unknown option $opt"
@@ -4311,6 +4316,24 @@ if test "$tpm" = ""; then
 elif test "$tpm" = "yes"; then
   if test "$mingw32" = "yes" ; then
     error_exit "TPM emulation only available on POSIX systems"
+  fi
+fi
+
+##########################################
+# libubpf probe
+
+if test "$libubpf" != "no" ; then
+  cat > $TMPC <<EOF
+#include <ubpf.h>
+int main(void) { ubpf_create(); return 0; }
+EOF
+  if compile_prog "" "-lubpf" ; then
+    libubpf=yes
+  else
+    if test "$libubpf" = "yes" ; then
+      feature_not_found "libubpf" "Install libubpf"
+    fi
+    libubpf=no
   fi
 fi
 
@@ -7019,6 +7042,7 @@ echo "fuzzing support   $fuzzing"
 echo "gdb               $gdb_bin"
 echo "rng-none          $rng_none"
 echo "Linux keyring     $secret_keyring"
+echo "libubpf           $libubpf"
 
 if test "$supported_cpu" = "no"; then
     echo
@@ -7444,6 +7468,9 @@ if test "$linux_io_uring" = "yes" ; then
   echo "CONFIG_LINUX_IO_URING=y" >> $config_host_mak
   echo "LINUX_IO_URING_CFLAGS=$linux_io_uring_cflags" >> $config_host_mak
   echo "LINUX_IO_URING_LIBS=$linux_io_uring_libs" >> $config_host_mak
+fi
+if test "$libubpf" = "yes" ; then
+  echo "CONFIG_LIBUBPF=y" >> $config_host_mak
 fi
 if test "$attr" = "yes" ; then
   echo "CONFIG_ATTR=y" >> $config_host_mak

--- a/hw/misc/Makefile.objs
+++ b/hw/misc/Makefile.objs
@@ -8,6 +8,7 @@ common-obj-$(CONFIG_ISA_TESTDEV) += pc-testdev.o
 common-obj-$(CONFIG_PCI_TESTDEV) += pci-testdev.o
 common-obj-$(CONFIG_EDU) += edu.o
 common-obj-$(CONFIG_PCA9552) += pca9552.o
+common-obj-$(CONFIG_LIBUBPF) += hermes.o
 
 common-obj-$(CONFIG_UNIMP) += unimp.o
 common-obj-$(CONFIG_EMPTY_SLOT) += empty_slot.o
@@ -93,3 +94,5 @@ obj-$(CONFIG_MAC_VIA) += mac_via.o
 common-obj-$(CONFIG_GRLIB) += grlib_ahb_apb_pnp.o
 
 obj-$(CONFIG_AVR_POWER) += avr_power.o
+
+hermes.o-libs := -lubpf

--- a/hw/misc/hermes.c
+++ b/hw/misc/hermes.c
@@ -22,25 +22,139 @@
  */
 
 #include "qemu/osdep.h"
+#include "qemu/units.h"
 #include "hw/pci/pci.h"
 
 #define TYPE_PCI_HERMES_DEVICE "hermes"
 #define HERMES(obj)       OBJECT_CHECK(HermesState, obj, TYPE_PCI_HERMES_DEVICE)
 
+#define HERMES_BAR0_SIZE          (32 * MiB)
+#define HERMES_EHVER_OFF     0x00
+#define HERMES_EHTS_OFF      0x04
+#define HERMES_EHENG_OFF     0x08
+#define HERMES_EHPSLOT_OFF   0x09
+#define HERMES_EHDSLOT_OFF   0x0A
+#define HERMES_EHPSOFF_OFF   0x0C
+#define HERMES_EHPSSZE_OFF   0x10
+#define HERMES_EHDSOFF_OFF   0x14
+#define HERMES_EHDSSZE_OFF   0x18
+
+#define HERMES_EHVER_VAL     1
+#define HERMES_EHTS_VAL      1602198883
+#define HERMES_EHENG_VAL     1
+#define HERMES_EHPSLOT_VAL   16
+#define HERMES_EHDSLOT_VAL   32
+#define HERMES_EHPSSZE_VAL   (1 * MiB)
+#define HERMES_EHDSSZE_VAL   (1 * MiB)
+#define HERMES_EHPSOFF_VAL   0
+#define HERMES_EHDSOFF_VAL   (HERMES_EHPSSZE_VAL * HERMES_EHPSLOT_VAL)
+
+struct hermes_bar0 {
+    uint32_t ehver;
+    uint32_t ehts;
+
+    uint8_t eheng;
+    uint8_t ehpslot;
+    uint8_t ehdslot;
+    uint8_t rsv0;
+
+    uint32_t ehdsoff;
+    uint32_t ehdssze;
+    uint32_t ehpsoff;
+    uint32_t ehpssze;
+
+    MemoryRegion mem_reg;
+};
+
 typedef struct {
     PCIDevice pdev;
+    struct hermes_bar0 *bar0;
 } HermesState;
+
+static uint64_t hermes_bar0_read(void *opaque, hwaddr addr, unsigned size)
+{
+    HermesState *hermes = opaque;
+    uint32_t *ptr;
+    uint32_t val = 0;
+
+    if (addr <= HERMES_EHPSSZE_OFF) {
+        ptr = (uint32_t *) &((uint8_t *) hermes->bar0)[addr];
+        val = *ptr;
+        switch (size) {
+        case 1:
+            val &= 0xFF;
+            break;
+        case 2:
+            val &= 0xFFFF;
+            break;
+        }
+    }
+
+    return val;
+}
+
+/* BAR 0 is read-only */
+static void hermes_bar0_write(void *opaque, hwaddr addr, uint64_t val,
+                unsigned size)
+{
+}
+
+static const MemoryRegionOps hermes_bar0_ops = {
+    .read = hermes_bar0_read,
+    .write = hermes_bar0_write,
+    .valid = {
+        .min_access_size = 1,
+        .max_access_size = 4,
+    },
+    .impl = {
+        .min_access_size = 1,
+        .max_access_size = 4,
+    },
+    .endianness = DEVICE_NATIVE_ENDIAN,
+};
 
 static void hermes_instance_init(Object *obj)
 {
+    HermesState *hermes = HERMES(obj);
+
+    hermes->bar0 = malloc(sizeof(*hermes->bar0));
+    if (hermes->bar0) {
+        hermes->bar0->ehver = HERMES_EHVER_VAL;
+        hermes->bar0->ehts = HERMES_EHTS_VAL;
+        hermes->bar0->eheng = HERMES_EHENG_VAL;
+        hermes->bar0->ehpslot = HERMES_EHPSLOT_VAL;
+        hermes->bar0->ehdslot = HERMES_EHDSLOT_VAL;
+
+        hermes->bar0->ehdssze = HERMES_EHDSSZE_VAL;
+        hermes->bar0->ehpssze = HERMES_EHPSSZE_VAL;
+        hermes->bar0->ehdsoff = HERMES_EHDSOFF_VAL;
+        hermes->bar0->ehpsoff = HERMES_EHPSOFF_VAL;
+
+    } else {
+        fprintf(stderr, "Hermes: Failed to allocate memory for BAR 0\n");
+    }
+    }
 }
 
 static void hermes_instance_finalize(Object *obj)
 {
+    HermesState *hermes = HERMES(obj);
+    if (hermes->bar0) {
+        free(hermes->bar0);
+    }
 }
 
 static void pci_hermes_realize(PCIDevice *pdev, Error **errp)
 {
+    HermesState *hermes = HERMES(pdev);
+
+    if (hermes->bar0) {
+        memory_region_init_io(&hermes->bar0->mem_reg, OBJECT(hermes),
+                              &hermes_bar0_ops, hermes, "hermes-bar0",
+                              HERMES_BAR0_SIZE);
+        pci_register_bar(pdev, 0, PCI_BASE_ADDRESS_SPACE_MEMORY,
+                         &hermes->bar0->mem_reg);
+    }
 }
 
 static void pci_hermes_uninit(PCIDevice *pdev)

--- a/hw/misc/hermes.c
+++ b/hw/misc/hermes.c
@@ -24,6 +24,7 @@
 #include "qemu/osdep.h"
 #include "qemu/units.h"
 #include "hw/pci/pci.h"
+#include "hw/pci/msix.h"
 #include "qapi/error.h"
 #include "trace.h"
 
@@ -53,6 +54,10 @@
 #define HERMES_EHDSSZE_VAL   (1 * MiB)
 #define HERMES_EHPSOFF_VAL   0
 #define HERMES_EHDSOFF_VAL   (HERMES_EHPSSZE_VAL * HERMES_EHPSLOT_VAL)
+
+#define HERMES_MSIX_VEC_NUM      32
+#define HERMES_MSIX_TABLE_OFFSET (0x8000)
+#define HERMES_MSIX_PBA_OFFSET   (0x8FE0)
 
 #define W1S(old, new) ((old) | (new))
 #define W1C(old, new) ((old) & ~(new))
@@ -929,6 +934,53 @@ static void bar2_init(HermesState *hermes)
     hermes->bar2->parent = hermes;
 }
 
+static void hermes_unuse_msix_vectors(HermesState *hermes, int num_vectors)
+{
+    int i;
+    for (i = 0; i < num_vectors; i++) {
+        msix_vector_unuse(PCI_DEVICE(hermes), i);
+    }
+}
+
+static bool hermes_use_msix_vectors(HermesState *hermes, int num_vectors)
+{
+    int i;
+    for (i = 0; i < num_vectors; i++) {
+        int res = msix_vector_use(PCI_DEVICE(hermes), i);
+        if (res < 0) {
+            trace_hermes_msix_use_vector_fail(i, res);
+            hermes_unuse_msix_vectors(hermes, i);
+            return false;
+        }
+    }
+    return true;
+}
+
+static void hermes_init_msix(HermesState *hermes)
+{
+    PCIDevice *dev = PCI_DEVICE(hermes);
+    int res = msix_init(dev, HERMES_MSIX_VEC_NUM, &hermes->bar2->mem_reg, 2,
+                        HERMES_MSIX_TABLE_OFFSET,
+                        &hermes->bar2->mem_reg, 2, HERMES_MSIX_PBA_OFFSET,
+                        0x0, &error_fatal);
+    if (res < 0) {
+        trace_hermes_msix_init_fail(res);
+    } else {
+        if (!hermes_use_msix_vectors(hermes, HERMES_MSIX_VEC_NUM)) {
+            msix_uninit(dev, &hermes->bar2->mem_reg, &hermes->bar2->mem_reg);
+        }
+    }
+}
+
+static void hermes_cleanup_msix(HermesState *hermes)
+{
+    if (msix_present(PCI_DEVICE(hermes))) {
+        hermes_unuse_msix_vectors(hermes, HERMES_MSIX_VEC_NUM);
+        msix_uninit(PCI_DEVICE(hermes), &hermes->bar2->mem_reg,
+                    &hermes->bar2->mem_reg);
+    }
+}
+
 static void hermes_instance_init(Object *obj)
 {
     HermesState *hermes = HERMES(obj);
@@ -996,6 +1048,8 @@ static void pci_hermes_realize(PCIDevice *pdev, Error **errp)
         pci_register_bar(pdev, 2,
                 PCI_BASE_ADDRESS_SPACE_MEMORY | PCI_BASE_ADDRESS_MEM_PREFETCH,
                 &hermes->bar2->mem_reg);
+
+        hermes_init_msix(hermes);
     }
 
     if (hermes->bar4) {
@@ -1009,6 +1063,9 @@ static void pci_hermes_realize(PCIDevice *pdev, Error **errp)
 
 static void pci_hermes_uninit(PCIDevice *pdev)
 {
+    HermesState *hermes = HERMES(pdev);
+
+    hermes_cleanup_msix(hermes);
 }
 
 static void hermes_class_init(ObjectClass *class, void *data)

--- a/hw/misc/hermes.c
+++ b/hw/misc/hermes.c
@@ -1,0 +1,80 @@
+/*
+ * Eid-Hermes eBPF-based PCIe Accelerator
+ * Copyright (c) 2020 Eidetic Communications Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "qemu/osdep.h"
+#include "hw/pci/pci.h"
+
+#define TYPE_PCI_HERMES_DEVICE "hermes"
+#define HERMES(obj)       OBJECT_CHECK(HermesState, obj, TYPE_PCI_HERMES_DEVICE)
+
+typedef struct {
+    PCIDevice pdev;
+} HermesState;
+
+static void hermes_instance_init(Object *obj)
+{
+}
+
+static void hermes_instance_finalize(Object *obj)
+{
+}
+
+static void pci_hermes_realize(PCIDevice *pdev, Error **errp)
+{
+}
+
+static void pci_hermes_uninit(PCIDevice *pdev)
+{
+}
+
+static void hermes_class_init(ObjectClass *class, void *data)
+{
+    PCIDeviceClass *k = PCI_DEVICE_CLASS(class);
+
+    k->realize = pci_hermes_realize;
+    k->exit = pci_hermes_uninit;
+    k->vendor_id = 0x1de5; /* Eideticom */
+    k->device_id = 0x3000;
+    k->revision = 0x1;
+    k->class_id = PCI_CLASS_OTHERS;
+}
+
+static void pci_hermes_register_types(void)
+{
+    static InterfaceInfo interfaces[] = {
+        { INTERFACE_CONVENTIONAL_PCI_DEVICE },
+        { },
+    };
+    static const TypeInfo hermes_info = {
+        .name          = TYPE_PCI_HERMES_DEVICE,
+        .parent        = TYPE_PCI_DEVICE,
+        .instance_size = sizeof(HermesState),
+        .instance_init = hermes_instance_init,
+        .instance_finalize = hermes_instance_finalize,
+        .class_init    = hermes_class_init,
+        .interfaces = interfaces,
+    };
+
+    type_register_static(&hermes_info);
+}
+type_init(pci_hermes_register_types)

--- a/hw/misc/trace-events
+++ b/hw/misc/trace-events
@@ -223,3 +223,7 @@ hermes_bar2_read(unsigned int size, uint64_t addr, uint64_t value) "Hermes BAR2 
 hermes_bar2_write(unsigned int size, uint64_t addr, uint64_t value) "Hermes BAR2 write sz:%u addr:0x%"PRIx64" data:0x%"PRIx64
 hermes_msix_init_fail(int32_t error) "Failed to initialize MSI-X, error %d"
 hermes_msix_use_vector_fail(uint32_t vec, int32_t error) "Failed to use MSI-X vector %d, error %d"
+hermes_dma_desc(uint32_t ctrl, uint32_t len, uint32_t src_addr_lo, uint32_t src_addr_hi, uint32_t dst_addr_lo, uint32_t dst_addr_hi, uint32_t nxt_addr_lo, uint32_t nxt_addr_hi) "Hermes DMA Desc: ctrl: 0x%"PRIx32" len: 0x%"PRIx32" src_addr_lo: 0x%"PRIx32" src_addr_hi: 0x%"PRIx32" dst_addr_lo: 0x%"PRIx32" dst_addr_hi: 0x%"PRIx32" nxt_addr_lo: 0x%"PRIx32" nxt_addr_hi: 0x%"PRIx32""
+hermes_dma(const char *channel, uint64_t src, uint64_t dst) "Hermes DMA %s 0x%" PRIx64" 0x%" PRIx64
+hermes_msix_notify(unsigned vector) "Hermes MSI-X notify %u"
+hermes_dma_num_adj(unsigned num_adj) "%u"

--- a/hw/misc/trace-events
+++ b/hw/misc/trace-events
@@ -221,3 +221,5 @@ pca955x_gpio_change(const char *description, unsigned id, unsigned prev_state, u
 # hermes.c
 hermes_bar2_read(unsigned int size, uint64_t addr, uint64_t value) "Hermes BAR2 read sz:%u addr:0x%"PRIx64" data:0x%"PRIx64
 hermes_bar2_write(unsigned int size, uint64_t addr, uint64_t value) "Hermes BAR2 write sz:%u addr:0x%"PRIx64" data:0x%"PRIx64
+hermes_msix_init_fail(int32_t error) "Failed to initialize MSI-X, error %d"
+hermes_msix_use_vector_fail(uint32_t vec, int32_t error) "Failed to use MSI-X vector %d, error %d"

--- a/hw/misc/trace-events
+++ b/hw/misc/trace-events
@@ -217,3 +217,7 @@ grlib_apb_pnp_read(uint64_t addr, uint32_t value) "APB PnP read addr:0x%03"PRIx6
 # pca9552.c
 pca955x_gpio_status(const char *description, const char *buf) "%s GPIOs 0-15 [%s]"
 pca955x_gpio_change(const char *description, unsigned id, unsigned prev_state, unsigned current_state) "%s GPIO id:%u status: %u -> %u"
+
+# hermes.c
+hermes_bar2_read(unsigned int size, uint64_t addr, uint64_t value) "Hermes BAR2 read sz:%u addr:0x%"PRIx64" data:0x%"PRIx64
+hermes_bar2_write(unsigned int size, uint64_t addr, uint64_t value) "Hermes BAR2 write sz:%u addr:0x%"PRIx64" data:0x%"PRIx64


### PR DESCRIPTION
This PR introduces the Hermes device to QEMU.

This device has the 3 BARs defined on [eid-hermes][1] and it can do DMA operations using the [xdma][2] driver. It currently has one C2H and one H2C channel. This has been tested to work with the example on [3], including with large buffers that span multiple DMA descriptors.

In the future we will add eBPF capabilities to this device.

[1]: https://github.com/Eideticom/eid-hermes/blob/master/specs/eid-hermes-interface.md#overall-bar-layout
[2]: https://github.com/aws/aws-fpga/tree/master/sdk/linux_kernel_drivers/xdma
[3]: https://github.com/aws/aws-fpga/tree/master/sdk/linux_kernel_drivers/xdma#quick-example