### PR TITLE
Dockerfile-hermes: change default HERMES_QEMU_REF

### DIFF
--- a/docker/hermes/docker-compose.yml
+++ b/docker/hermes/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       dockerfile: ./Dockerfile
       context: ./
       args:
-        HERMES_QEMU_REF: martin/hermes_v3
+        HERMES_QEMU_REF: hermes
     user: root
     network_mode: host
     privileged: true


### PR DESCRIPTION
Now that the Hermes device has been merged, we can change the default
branch used by the docker-compose.