### PR TITLE
Compute number of descriptors in next DMA block correctly

### DIFF
--- a/hw/misc/hermes.c
+++ b/hw/misc/hermes.c
@@ -200,7 +200,7 @@ static int hermes_execute_descs(HermesState *hermes,
     }
 
     *desc_addr = desc[*num_desc - 1].nxt_addr;
-    *num_desc = (desc[*num_desc - 1].ctrl >> 8) & 0x3F;
+    *num_desc = 1 + ((desc[*num_desc - 1].ctrl >> 8) & 0x3F);
 
     g_free(desc);
 


### PR DESCRIPTION
DMA descriptors are processed in blocks, and the last descriptor of a
block points to the address and number of *adjacent* descriptors in the
next block (Nxt_adj and Nxt_addr on Table 5 of PG195[1]).

However, we were not computing the number of descriptors in subsequent
blocks properly, because we weren't adding 1 to account for the first
descriptor (it is valid to have nxt_adj == 0).

This has been tested with a 32MB XDMA transfer.

Fixes: 9d38cf97af58 ("Implement DMA on Hermes")

[1]: https://www.xilinx.com/support/documentation/ip_documentation/xdma/v4_1/pg195-pcie-dma.pdf

Signed-off-by: Martin Oliveira <martin.oliveira@eideticom.com>