### PR TITLE
trace-events: fix broken compilation

### DIFF
--- a/hw/misc/trace-events
+++ b/hw/misc/trace-events
@@ -222,6 +222,6 @@ pca955x_gpio_change(const char *description, unsigned id, unsigned prev_state, u
 hermes_bar2_read(unsigned int size, uint64_t addr, uint64_t value) "Hermes BAR2 read sz:%u addr:0x%"PRIx64" data:0x%"PRIx64
 hermes_bar2_write(unsigned int size, uint64_t addr, uint64_t value) "Hermes BAR2 write sz:%u addr:0x%"PRIx64" data:0x%"PRIx64
 hermes_dma(const char *channel, uint64_t src, uint64_t dst, uint64_t len) "Hermes DMA %s src: 0x%" PRIx64" dst: 0x%" PRIx64 " len: %lu"
-hermes_dma_desc(uint32_t ctrl, uint32_t len, uint64_t src_addr, uint64_t dst_addr, uint64_t nxt_addr) "Hermes DMA Desc: ctrl: 0x%"PRIx32" len: 0x%"PRIx32" src_addr: 0x%"PRIx64" dst_addr: 0x%"PRIx64" nxt_addr: 0x%"PRIx64"
+hermes_dma_desc(uint32_t ctrl, uint32_t len, uint64_t src_addr, uint64_t dst_addr, uint64_t nxt_addr) "Hermes DMA Desc: ctrl: 0x%"PRIx32" len: 0x%"PRIx32" src_addr: 0x%"PRIx64" dst_addr: 0x%"PRIx64" nxt_addr: 0x%"PRIx64
 hermes_dma_num_adj(unsigned num_adj) "Hermes DMA: num adj: %u"
 hermes_msix_notify(unsigned vector) "Hermes MSI-X notify %u"


### PR DESCRIPTION
When trying to compile without traces with gcc 9.3.0, the build would
fail with syntax errors. This was caused by a trailing " on a trace
definition.

Fixes: 9d38cf9 ("Implement DMA on Hermes")
Resolves: #11