### PR TITLE
hermes: make bar0 struct packed

### DIFF
--- a/hw/misc/hermes.c
+++ b/hw/misc/hermes.c
@@ -71,7 +71,7 @@
 
 typedef struct HermesState HermesState;
 
-static const struct hermes_bar0 {
+static const struct __attribute__((__packed__)) hermes_bar0 {
     uint32_t ehver;
     char ehbld[48];
 


### PR DESCRIPTION
This was missing and caused errors when we tried to increase the offsets (EHPSOFF and EHDSOFF) to 8 bytes.